### PR TITLE
Set Powershell to use TLS v1.2

### DIFF
--- a/SpaceX/SpaceX.psm1
+++ b/SpaceX/SpaceX.psm1
@@ -17,4 +17,6 @@ Foreach ($import in @($Public + $Private))
 
 # Export all the functions
 Export-ModuleMember -Function $Public.Basename -Alias *
-  
+
+# Set Powershell to use TLS v1.2 (minimum supported by SpaceX API)
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
The SpaceX API requires TLS v1.2 or greater. The default in Powershell is less than this! Setting it to use TLS v1.2 during the module import resolves this.

If no one else is having this issue, then maybe it's just something on my config, so this PR might not be required...??