### PR TITLE
Add Pester tests

### DIFF
--- a/SpaceX/SpaceX.Tests.ps1
+++ b/SpaceX/SpaceX.Tests.ps1
@@ -21,9 +21,9 @@ Describe 'comment based help' {
         $ast = [System.Management.Automation.Language.Parser]::ParseInput((Get-Content function:$function), [ref]$null, [ref]$null)
 
         Context "$function"{
-            It 'has Synopsis' {$help.Synopsis | Should not BeNullOrEmpty}
-            It 'has Description' {$help.Description | Should not BeNullOrEmpty}
-            It 'has Github URL in Notes' { $notes[0].trim() | Should BeExactly "https://github.com/lazywinadmin/SpaceX" }
+            It 'has Synopsis' {$help.Synopsis | Should -Not -BeNullOrEmpty}
+            It 'has Description' {$help.Description | Should -Not -BeNullOrEmpty}
+            It 'has Github URL in Notes' { $notes[0].trim() | Should -BeExactly "https://github.com/lazywinadmin/SpaceX" }
 
             # Get the parameters declared in the Comment Based Help
             $helpParameters = $help.parameters.parameter
@@ -32,7 +32,7 @@ Describe 'comment based help' {
             $astParameters = $ast.ParamBlock.Parameters.Name.variablepath.userpath
 
             It 'has the correct number of parameters' {
-                $helpParameters.name.count -eq $astParameters.count | Should Be $true
+                $helpParameters.name.count -eq $astParameters.count | Should -BeTrue
             }
 
             # Parameter Description
@@ -40,15 +40,16 @@ Describe 'comment based help' {
             If (-not [String]::IsNullOrEmpty($astParameters)) {
                 $helpParameters | ForEach-Object {
                     It "has a description for parameter $($_.Name)" {
-                        $_.description | Should not BeNullOrEmpty
+                        $_.description | Should -Not -BeNullOrEmpty
                     }
                 }
             }
 
             # Examples
             It 'has Examples' {
-                $help.examples.example.code.count | Should BeGreaterthan 0
+                $help.examples.example.code.count | Should -BeGreaterThan 0
             }
+            write-host $help.examples.example.code
 
             # Examples - Remarks (small description that comes with the example)
             $exampleNumber = 0
@@ -56,7 +57,7 @@ Describe 'comment based help' {
             {
                 $exampleNumber ++
                 It "has remarks for Example $exampleNumber" {
-                    (-join $example.remarks.text) | Should not BeNullOrEmpty
+                    (-join $example.remarks.text) | Should -Not -BeNullOrEmpty
                 }
             }
         }
@@ -72,7 +73,7 @@ Describe 'Get-SXApi' {
         $returnedData = Get-SXApi
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }
@@ -83,7 +84,7 @@ Describe 'Get-SXCapsule' {
         $returnedData = Get-SXCapsule
         
         It 'gets an object array' {
-            $returnedData.getType() | Should Be 'System.Object[]'
+            $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
     
@@ -91,7 +92,7 @@ Describe 'Get-SXCapsule' {
         $returnedData = Get-SXCapsule -Capsule C109
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }
@@ -102,7 +103,7 @@ Describe 'Get-SXCompany' {
         $returnedData = Get-SXCompany
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }
@@ -113,7 +114,7 @@ Describe 'Get-SXCore' {
         $returnedData = Get-SXCore
         
         It 'gets an object array' {
-            $returnedData.getType() | Should Be 'System.Object[]'
+            $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
     
@@ -121,7 +122,7 @@ Describe 'Get-SXCore' {
         $returnedData = Get-SXCore -Serial B1032
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }
@@ -132,7 +133,7 @@ Describe 'Get-SXDragon' {
         $returnedData = Get-SXDragon
         
         It 'gets an object array' {
-            $returnedData.getType() | Should Be 'System.Object[]'
+            $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
     
@@ -140,7 +141,7 @@ Describe 'Get-SXDragon' {
         $returnedData = Get-SXDragon -ID dragon1
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }
@@ -151,7 +152,7 @@ Describe 'Get-SXHistory' {
         $returnedData = Get-SXHistory
         
         It 'gets an object array' {
-            $returnedData.getType() | Should Be 'System.Object[]'
+            $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
     
@@ -159,7 +160,7 @@ Describe 'Get-SXHistory' {
         $returnedData = Get-SXHistory -ID 1
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }
@@ -170,7 +171,7 @@ Describe 'Get-SXLaunch' {
         $returnedData = Get-SXLaunch
         
         It 'gets an object array' {
-            $returnedData.getType() | Should Be 'System.Object[]'
+            $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
     
@@ -178,7 +179,7 @@ Describe 'Get-SXLaunch' {
         $returnedData = Get-SXLaunch -Latest
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
     
@@ -186,7 +187,7 @@ Describe 'Get-SXLaunch' {
         $returnedData = Get-SXLaunch -Upcoming
         
         It 'gets an object array' {
-            $returnedData.getType() | Should Be 'System.Object[]'
+            $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
 }
@@ -197,7 +198,7 @@ Describe 'Get-SXLaunchpad' {
         $returnedData = Get-SXLaunchpad
         
         It 'gets an object array' {
-            $returnedData.getType() | Should Be 'System.Object[]'
+            $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
     
@@ -205,7 +206,7 @@ Describe 'Get-SXLaunchpad' {
         $returnedData = Get-SXLaunchpad -Launchpad stls
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }
@@ -216,7 +217,7 @@ Describe 'Get-SXMission' {
         $returnedData = Get-SXMission
         
         It 'gets an object array' {
-            $returnedData.getType() | Should Be 'System.Object[]'
+            $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
     
@@ -224,7 +225,7 @@ Describe 'Get-SXMission' {
         $returnedData = Get-SXMission -Mission F3364BF
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }
@@ -235,7 +236,7 @@ Describe 'Get-SXPayload' {
         $returnedData = Get-SXPayload
         
         It 'gets an object array' {
-            $returnedData.getType() | Should Be 'System.Object[]'
+            $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
     
@@ -243,7 +244,7 @@ Describe 'Get-SXPayload' {
         $returnedData = Get-SXPayload -PayloadID "CRS-19"
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }
@@ -254,7 +255,7 @@ Describe 'Get-SXRoadster' {
         $returnedData = Get-SXRoadster
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }
@@ -265,7 +266,7 @@ Describe 'Get-SXRocket' {
         $returnedData = Get-SXRocket
         
         It 'gets an object array' {
-            $returnedData.getType() | Should Be 'System.Object[]'
+            $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
     
@@ -273,7 +274,7 @@ Describe 'Get-SXRocket' {
         $returnedData = Get-SXRocket -Rocket falconheavy
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }
@@ -284,7 +285,7 @@ Describe 'Get-SXShip' {
         $returnedData = Get-SXShip
         
         It 'gets an object array' {
-            $returnedData.getType() | Should Be 'System.Object[]'
+            $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
     
@@ -292,7 +293,7 @@ Describe 'Get-SXShip' {
         $returnedData = Get-SXShip -ShipID RACHEL
         
         It 'gets a single object' {
-            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+            $returnedData.getType() | Should -Be 'System.Management.Automation.PSCustomObject'
         }
     }
 }

--- a/SpaceX/SpaceX.Tests.ps1
+++ b/SpaceX/SpaceX.Tests.ps1
@@ -1,0 +1,236 @@
+$ThisModule = $MyInvocation.MyCommand.Path -replace '\.Tests\.ps1$'
+$ThisModuleName = $ThisModule | Split-Path -Leaf
+
+Get-Module -Name $ThisModuleName -All | Remove-Module -Force -ErrorAction Ignore
+
+Import-Module -Name "$ThisModule.psm1" -Force -ErrorAction Stop
+
+Describe 'Get-SXApi' {
+    Context 'no parameters' {
+        $returnedData = Get-SXApi
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}
+
+
+Describe 'Get-SXCapsule' {
+    Context 'no parameters' {
+        $returnedData = Get-SXCapsule
+        
+        It 'gets an object array' {
+            $returnedData.getType() | Should Be 'System.Object[]'
+        }
+    }
+    
+    Context 'specify Capsule' {
+        $returnedData = Get-SXCapsule -Capsule C109
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}
+
+
+Describe 'Get-SXCompany' {
+    Context 'no parameters' {
+        $returnedData = Get-SXCompany
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}
+
+
+Describe 'Get-SXCore' {
+    Context 'no parameters' {
+        $returnedData = Get-SXCore
+        
+        It 'gets an object array' {
+            $returnedData.getType() | Should Be 'System.Object[]'
+        }
+    }
+    
+    Context 'specify Serial' {
+        $returnedData = Get-SXCore -Serial B1032
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}
+
+
+Describe 'Get-SXDragon' {
+    Context 'no parameters' {
+        $returnedData = Get-SXDragon
+        
+        It 'gets an object array' {
+            $returnedData.getType() | Should Be 'System.Object[]'
+        }
+    }
+    
+    Context 'specify ID' {
+        $returnedData = Get-SXDragon -ID dragon1
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}
+
+
+Describe 'Get-SXHistory' {
+    Context 'no parameters' {
+        $returnedData = Get-SXHistory
+        
+        It 'gets an object array' {
+            $returnedData.getType() | Should Be 'System.Object[]'
+        }
+    }
+    
+    Context 'specify ID' {
+        $returnedData = Get-SXHistory -ID 1
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}
+
+
+Describe 'Get-SXLaunch' {
+    Context 'no parameters' {
+        $returnedData = Get-SXLaunch
+        
+        It 'gets an object array' {
+            $returnedData.getType() | Should Be 'System.Object[]'
+        }
+    }
+    
+    Context 'specify Latest' {
+        $returnedData = Get-SXLaunch -Latest
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+    
+    Context 'specify Upcoming' {
+        $returnedData = Get-SXLaunch -Upcoming
+        
+        It 'gets an object array' {
+            $returnedData.getType() | Should Be 'System.Object[]'
+        }
+    }
+}
+
+
+Describe 'Get-SXLaunchpad' {
+    Context 'no parameters' {
+        $returnedData = Get-SXLaunchpad
+        
+        It 'gets an object array' {
+            $returnedData.getType() | Should Be 'System.Object[]'
+        }
+    }
+    
+    Context 'specify Launchpad' {
+        $returnedData = Get-SXLaunchpad -Launchpad stls
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}
+
+
+Describe 'Get-SXMission' {
+    Context 'no parameters' {
+        $returnedData = Get-SXMission
+        
+        It 'gets an object array' {
+            $returnedData.getType() | Should Be 'System.Object[]'
+        }
+    }
+    
+    Context 'specify Mission' {
+        $returnedData = Get-SXMission -Mission F3364BF
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}
+
+
+Describe 'Get-SXPayload' {
+    Context 'no parameters' {
+        $returnedData = Get-SXPayload
+        
+        It 'gets an object array' {
+            $returnedData.getType() | Should Be 'System.Object[]'
+        }
+    }
+    
+    Context 'specify PayloadID' {
+        $returnedData = Get-SXPayload -PayloadID "CRS-19"
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}
+
+
+Describe 'Get-SXRoadster' {
+    Context 'no parameters' {
+        $returnedData = Get-SXRoadster
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}
+
+
+Describe 'Get-SXRocket' {
+    Context 'no parameters' {
+        $returnedData = Get-SXRocket
+        
+        It 'gets an object array' {
+            $returnedData.getType() | Should Be 'System.Object[]'
+        }
+    }
+    
+    Context 'specify Rocket' {
+        $returnedData = Get-SXRocket -Rocket falconheavy
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}
+
+
+Describe 'Get-SXShip' {
+    Context 'no parameters' {
+        $returnedData = Get-SXShip
+        
+        It 'gets an object array' {
+            $returnedData.getType() | Should Be 'System.Object[]'
+        }
+    }
+    
+    Context 'specify ShipID' {
+        $returnedData = Get-SXShip -ShipID RACHEL
+        
+        It 'gets a single object' {
+            $returnedData.getType() | Should Be 'System.Management.Automation.PSCustomObject'
+        }
+    }
+}

--- a/SpaceX/public/Get-SXApi.ps1
+++ b/SpaceX/public/Get-SXApi.ps1
@@ -8,10 +8,11 @@ function Get-SXApi
     Retrieve SpaceX API data
     
     .EXAMPLE
-    Get-SXApi
+    C:\PS> Get-SXApi
+    Gets the API data
     
     .NOTES
-    https://github.com/lazywinadmin/spacex
+    https://github.com/lazywinadmin/SpaceX
     #>
 [CmdletBinding()]
 PARAM()

--- a/SpaceX/public/Get-SXCapsule.ps1
+++ b/SpaceX/public/Get-SXCapsule.ps1
@@ -6,14 +6,19 @@ function Get-SXCapsule {
     .DESCRIPTION
     Retrieve SpaceX capsule data
     
+    .PARAMETER Capsule
+    The serial number of a specific capsule
+    
     .EXAMPLE
-    Get-SXCapsule
+    C:\PS> Get-SXCapsule
+    Gets data about all the capsules
 
     .EXAMPLE
-    Get-SXCapsule -Capsule C109
+    C:\PS> Get-SXCapsule -Capsule C109
+    Gets data about the capsule with the specified serial
     
     .NOTES
-    https://github.com/lazywinadmin/spacex
+    https://github.com/lazywinadmin/SpaceX
     #>
     [CmdletBinding()]
     PARAM($Capsule)

--- a/SpaceX/public/Get-SXCompany.ps1
+++ b/SpaceX/public/Get-SXCompany.ps1
@@ -8,10 +8,11 @@ function Get-SXCompany
     Retrieve SpaceX Company data
     
     .EXAMPLE
-    Get-SXCompany
+    C:\PS> Get-SXCompany
+    Gets the company data
     
     .NOTES
-    https://github.com/lazywinadmin/spacex
+    https://github.com/lazywinadmin/SpaceX
     #>
 [CmdletBinding()]
 PARAM()

--- a/SpaceX/public/Get-SXCore.ps1
+++ b/SpaceX/public/Get-SXCore.ps1
@@ -10,13 +10,15 @@ function Get-SXCore {
   Specify the Core Serial
   
   .EXAMPLE
-  Get-SXCore
+  C:\PS> Get-SXCore
+  Gets data about all the cores
 
   .EXAMPLE
-  Get-SXCore -Serial B1032
+  C:\PS> Get-SXCore -Serial B1032
+  Gets data about the core with the specified serial
   
   .NOTES
-  https://github.com/lazywinadmin/spacex
+  https://github.com/lazywinadmin/SpaceX
   #>
   [CmdletBinding()]
   PARAM($Serial)

--- a/SpaceX/public/Get-SXDragon.ps1
+++ b/SpaceX/public/Get-SXDragon.ps1
@@ -10,13 +10,15 @@ function Get-SXDragon {
   Specify the Dragon Capsule ID
   
   .EXAMPLE
-  Get-SXDragon
+  C:\PS> Get-SXDragon
+  Gets data about all the dragons
 
   .EXAMPLE
   Get-SXDragon -ID dragon1
+  Gets data about the dragon with the specified ID
   
   .NOTES
-  https://github.com/lazywinadmin/spacex
+  https://github.com/lazywinadmin/SpaceX
   #>
   [CmdletBinding()]
   PARAM($ID)

--- a/SpaceX/public/Get-SXHistory.ps1
+++ b/SpaceX/public/Get-SXHistory.ps1
@@ -10,13 +10,15 @@ function Get-SXHistory {
   Specify the historical event ID
   
   .EXAMPLE
-  Get-SXHistory
+  C:\PS> Get-SXHistory
+  Gets all the history data
 
   .EXAMPLE
-  Get-SXHistory -ID 1
+  C:\PS> Get-SXHistory -ID 1
+  Gets data for the history event with the specified ID
   
   .NOTES
-  https://github.com/lazywinadmin/spacex
+  https://github.com/lazywinadmin/SpaceX
   #>
   [CmdletBinding()]
   PARAM($ID)

--- a/SpaceX/public/Get-SXLaunch.ps1
+++ b/SpaceX/public/Get-SXLaunch.ps1
@@ -6,17 +6,26 @@ function Get-SXLaunch {
     .DESCRIPTION
     Retrieve SpaceX launch data
     
+    .PARAMETER Latest
+    Just get data for the latest launch
+    
+    .PARAMETER Upcoming
+    Just get data for upcoming launches
+    
     .EXAMPLE
     Get-SXLaunch
+    Gets data for all the launches
 
     .EXAMPLE
     Get-SXLaunch -Latest
+    Gets data for the latest launch
 
     .EXAMPLE
     Get-SXLaunch -Upcoming
+    Gets data for upcoming launches
     
     .NOTES
-    https://github.com/lazywinadmin/spacex
+    https://github.com/lazywinadmin/SpaceX
     #>
     [CmdletBinding()]
     PARAM(

--- a/SpaceX/public/Get-SXLaunchPad.ps1
+++ b/SpaceX/public/Get-SXLaunchPad.ps1
@@ -6,14 +6,19 @@ function Get-SXLaunchpad {
     .DESCRIPTION
     Retrieve SpaceX launch sites data
     
+    .PARAMETER LaunchPad
+    The Site ID of a specific launch pad
+    
     .EXAMPLE
-    Get-SXLaunchpad
+    C:\PS> Get-SXLaunchpad
+    Gets data about all the launch pads
 
     .EXAMPLE
-    Get-SXLaunchpad -Launchpad stls
+    C:\PS> Get-SXLaunchpad -Launchpad stls
+    Gets data for the launch pad with the specified Site ID
     
     .NOTES
-    https://github.com/lazywinadmin/spacex
+    https://github.com/lazywinadmin/SpaceX
     #>
     [CmdletBinding()]
     PARAM($LaunchPad)

--- a/SpaceX/public/Get-SXMission.ps1
+++ b/SpaceX/public/Get-SXMission.ps1
@@ -10,13 +10,15 @@ function Get-SXMission {
     Specify the mission ID
     
     .EXAMPLE
-    Get-SXMission
+    C:\PS> Get-SXMission
+    Gets data for all the missions
 
     .EXAMPLE
-    Get-SXMission -Mission F3364BF
+    C:\PS> Get-SXMission -Mission F3364BF
+    Gets data for the mission with the specified Mission ID
     
     .NOTES
-    https://github.com/lazywinadmin/spacex
+    https://github.com/lazywinadmin/SpaceX
     #>
     [CmdletBinding()]
     PARAM($Mission)

--- a/SpaceX/public/Get-SXPayload.ps1
+++ b/SpaceX/public/Get-SXPayload.ps1
@@ -10,13 +10,15 @@ function Get-SXPayload {
   Specify the Payload ID
   
   .EXAMPLE
-  Get-SXPayload
+  C:\PS> Get-SXPayload
+  Gets data about all the payloads
 
   .EXAMPLE
-  Get-SXPayload -PayloadID "CRS-19"
+  C:\PS> Get-SXPayload -PayloadID "CRS-19"
+  Gets data for the payload with the specified ID
   
   .NOTES
-  https://github.com/lazywinadmin/spacex
+  https://github.com/lazywinadmin/SpaceX
   #>
   [CmdletBinding()]
   PARAM($PayloadID)

--- a/SpaceX/public/Get-SXRoadster.ps1
+++ b/SpaceX/public/Get-SXRoadster.ps1
@@ -8,9 +8,10 @@ function Get-SXRoadster {
 
   .EXAMPLE
   Get-SXRoadster
+  Gets data about the roadster
   
   .NOTES
-  https://github.com/lazywinadmin/spacex
+  https://github.com/lazywinadmin/SpaceX
   #>
   [CmdletBinding()]
   PARAM()

--- a/SpaceX/public/Get-SXRocket.ps1
+++ b/SpaceX/public/Get-SXRocket.ps1
@@ -11,12 +11,14 @@ function Get-SXRocket {
     
     .EXAMPLE
     Get-SXRocket
+    Gets data about all the rockets
 
     .EXAMPLE
     Get-SXRocket -Rocket falconheavy
+    Gets data about the rocket with the specified Rocket ID
     
     .NOTES
-    https://github.com/lazywinadmin/spacex
+    https://github.com/lazywinadmin/SpaceX
     #>
     [CmdletBinding()]
     PARAM($Rocket)

--- a/SpaceX/public/Get-SXShip.ps1
+++ b/SpaceX/public/Get-SXShip.ps1
@@ -10,13 +10,15 @@ function Get-SXShip {
   Specify the ship ID
   
   .EXAMPLE
-  Get-SXShip
+  C:\PS> Get-SXShip
+  Gets data about all ships
 
   .EXAMPLE
-  Get-SXShip -ShipID RACHEL
+  C:\PS> Get-SXShip -ShipID RACHEL
+  Gets data aobut the ship with the specified Ship ID
   
   .NOTES
-  https://github.com/lazywinadmin/spacex
+  https://github.com/lazywinadmin/SpaceX
   #>
   [CmdletBinding()]
   PARAM($ShipID)


### PR DESCRIPTION
Most of the code was shamelessly borrowed from https://lazywinadmin.com/2016/05/using-pester-to-test-your-comment-based.html 😉 

It uses the Pester v 4.x syntax.

Tests ensure that each function has in it's help:
 - a synopsis
 - a description
 - the Github URL in the notes
 - a description for each parameter
 - a comment for each example

Tests also verify that single objects or arrays are returned from the API calls as expected.

The functions were updated so the tests would pass (changes were only required to the help - no actual code was changed).

Resolves #1 