### PR TITLE
Make parameters on Get-SXLaunch mutually exclusive

### DIFF
--- a/SpaceX/SpaceX.Tests.ps1
+++ b/SpaceX/SpaceX.Tests.ps1
@@ -190,6 +190,14 @@ Describe 'Get-SXLaunch' {
             $returnedData.getType() | Should -Be 'System.Object[]'
         }
     }
+    
+    Context 'specify both Latest and Upcoming' {
+        $returnedData = Get-SXLaunch -Latest
+        
+        It 'is disallowed' {
+            {Get-SXLaunch -Latest -Upcoming} | Should -Throw
+        }
+    }
 }
 
 

--- a/SpaceX/public/Get-SXLaunch.ps1
+++ b/SpaceX/public/Get-SXLaunch.ps1
@@ -27,10 +27,10 @@ function Get-SXLaunch {
     .NOTES
     https://github.com/lazywinadmin/SpaceX
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Default')]
     PARAM(
-        [switch]$Latest,
-        [switch]$Upcoming)
+        [Parameter(ParameterSetName='Latest')][switch]$Latest,
+        [Parameter(ParameterSetName='Upcoming')][switch]$Upcoming)
     try {
         if ($Latest) {
             $Splat = @{

--- a/Tests/SpaceX.Tests.ps1
+++ b/Tests/SpaceX.Tests.ps1
@@ -264,8 +264,6 @@ Describe 'Get-SXLaunch' {
     }
     
     Context 'specify both Latest and Upcoming' {
-        $returnedData = Get-SXLaunch -Latest
-        
         It 'is disallowed' {
             {Get-SXLaunch -Latest -Upcoming} | Should -Throw
         }


### PR DESCRIPTION
Valid calls to Get-SXLaunch should be with:
 - No parameters (all launches)
 - Upcoming (only upcoming launches)
 - Latest (only the latest launch)

Using `Upcoming` and `Latest` together should not be allowed.

The original help for `Get-SXLaunch` shows that both switches are optional, and allowed together:

```powershell
SYNTAX
    Get-SXLaunch [-Latest] [-Upcoming] [<CommonParameters>]
```

After modification, it now shows that 3 forms of the command are valid, keeping the switches mutually exclusive:

```powershell
SYNTAX
    Get-SXLaunch [<CommonParameters>]

    Get-SXLaunch [-Latest] [<CommonParameters>]

    Get-SXLaunch [-Upcoming] [<CommonParameters>]
```