### PR TITLE
Only change TLS settings if required

### DIFF
--- a/SpaceX/SpaceX.psm1
+++ b/SpaceX/SpaceX.psm1
@@ -18,5 +18,27 @@ Foreach ($import in @($Public + $Private))
 # Export all the functions
 Export-ModuleMember -Function $Public.Basename -Alias *
 
-# Set Powershell to use TLS v1.2 (minimum supported by SpaceX API)
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+# Test to see if we can query the API now, or if we need to specifically
+# tell PowerShell to allow TLS v1.2 (minimum supported by SpaceX API)
+$SecurityProtocolTweakRequired = $False
+TRY
+{
+	Get-SXApi|Out-Null
+	# If no exception, then it must have worked - carry on"
+}
+CATCH [System.Net.WebException]
+{
+	# First attempt failed - enable TLS v1.2 and try again"
+	$script:SecurityProtocolTweakRequired = $true
+
+	TRY
+	{
+		Get-SXApi|Out-Null
+		# If no exception, then it must have worked this time - carry on"
+	}
+	CATCH [System.Net.WebException]
+	{
+		# Still got an exception - must be another issue, re-raise it"
+		throw
+	}
+}

--- a/SpaceX/private/Get-SXData.ps1
+++ b/SpaceX/private/Get-SXData.ps1
@@ -31,7 +31,6 @@ PARAM($Path)
     
     Try {
         Invoke-RestMethod -Uri https://api.spacexdata.com/v3/$Path
-        $a = 1/0
     }
     
     Finally {

--- a/SpaceX/private/Get-SXData.ps1
+++ b/SpaceX/private/Get-SXData.ps1
@@ -1,0 +1,43 @@
+function Get-SXData
+{
+    <#
+    .SYNOPSIS
+    Retrieve data from the SpaceX API
+    
+    .DESCRIPTION
+    Retrieve data from the SpaceX API. When the module was initialised,
+    tests were performed to see whether TLS v1.2 needs to be manually
+    enabled. If so, then it is enabled before making the call and reset
+    again afterwards.
+    
+    .PARAMETER Path
+    The path to the specific API being queried
+    
+    .EXAMPLE
+    Get-SXData -Path missions
+    Invokes the URL https://api.spacexdata.com/v3/missions
+    
+    .NOTES
+    https://github.com/lazywinadmin/SpaceX
+    #>
+[CmdletBinding()]
+PARAM($Path)
+    If ($script:SecurityProtocolTweakRequired) {
+        $originalSecurityProtocol = [Net.ServicePointManager]::SecurityProtocol
+        
+        [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
+        Write-Verbose "Temporarily changing SecurityProtocol from [$originalSecurityProtocol] to [$([Net.ServicePointManager]::SecurityProtocol)]"
+    }
+    
+    Try {
+        Invoke-RestMethod -Uri https://api.spacexdata.com/v3/$Path
+        $a = 1/0
+    }
+    
+    Finally {
+        If ($script:SecurityProtocolTweakRequired) {
+            [Net.ServicePointManager]::SecurityProtocol = $originalSecurityProtocol
+            Write-Verbose "Resetting SecurityProtocol back to [$([Net.ServicePointManager]::SecurityProtocol)]"
+        }
+    }
+} 

--- a/SpaceX/public/Get-SXApi.ps1
+++ b/SpaceX/public/Get-SXApi.ps1
@@ -16,5 +16,5 @@ function Get-SXApi
     #>
 [CmdletBinding()]
 PARAM()
-    Invoke-RestMethod -Uri https://api.spacexdata.com/v3
+    Get-SXData
 }

--- a/SpaceX/public/Get-SXCapsule.ps1
+++ b/SpaceX/public/Get-SXCapsule.ps1
@@ -25,16 +25,15 @@ function Get-SXCapsule {
     try {
         if ($Capsule) {
             $Splat = @{
-                Uri = "https://api.spacexdata.com/v3/capsules/$Capsule"
+                Path = "capsules/$Capsule"
             }
         }
         else {
             $Splat = @{
-                Uri = "https://api.spacexdata.com/v3/capsules"
+                Path = "capsules"
             }
         }
-
-        (Invoke-RestMethod @Splat)
+        (Get-SXData @Splat)
     }
     catch {
         $PSCmdlet.ThrowTerminatingError($_)

--- a/SpaceX/public/Get-SXCompany.ps1
+++ b/SpaceX/public/Get-SXCompany.ps1
@@ -16,5 +16,5 @@ function Get-SXCompany
     #>
 [CmdletBinding()]
 PARAM()
-    Invoke-RestMethod -Uri https://api.spacexdata.com/v3/info
+    Get-SXData -Path info
 }

--- a/SpaceX/public/Get-SXCore.ps1
+++ b/SpaceX/public/Get-SXCore.ps1
@@ -26,16 +26,16 @@ function Get-SXCore {
       if($Serial)
       {
           $Splat = @{
-              Uri = "https://api.spacexdata.com/v3/cores/$Serial"
+              Path = "cores/$Serial"
           }
       }
       else{
           $Splat = @{
-              Uri = "https://api.spacexdata.com/v3/cores"
+              Path = "cores"
           }
       }
 
-      (Invoke-RestMethod @Splat)
+      (Get-SXData @Splat)
   }
   catch{
       $PSCmdlet.ThrowTerminatingError($_)

--- a/SpaceX/public/Get-SXDragon.ps1
+++ b/SpaceX/public/Get-SXDragon.ps1
@@ -26,16 +26,16 @@ function Get-SXDragon {
       if($ID)
       {
           $Splat = @{
-              Uri = "https://api.spacexdata.com/v3/dragons/$ID"
+              Path = "dragons/$ID"
           }
       }
       else{
           $Splat = @{
-              Uri = "https://api.spacexdata.com/v3/dragons"
+              Path = "dragons"
           }
       }
 
-      (Invoke-RestMethod @Splat)
+      (Get-SXData @Splat)
   }
   catch{
       $PSCmdlet.ThrowTerminatingError($_)

--- a/SpaceX/public/Get-SXHistory.ps1
+++ b/SpaceX/public/Get-SXHistory.ps1
@@ -26,16 +26,16 @@ function Get-SXHistory {
       if($ID)
       {
           $Splat = @{
-              Uri = "https://api.spacexdata.com/v3/history/$ID"
+              Path = "history/$ID"
           }
       }
       else{
           $Splat = @{
-              Uri = "https://api.spacexdata.com/v3/history"
+              Path = "history"
           }
       }
 
-      (Invoke-RestMethod @Splat)
+      (Get-SXData @Splat)
   }
   catch{
       $PSCmdlet.ThrowTerminatingError($_)

--- a/SpaceX/public/Get-SXLaunch.ps1
+++ b/SpaceX/public/Get-SXLaunch.ps1
@@ -34,22 +34,22 @@ function Get-SXLaunch {
     try {
         if ($Latest) {
             $Splat = @{
-                Uri = "https://api.spacexdata.com/v3/launches/latest"
+                Path = "launches/latest"
             }
         }
         elseif ($Upcoming) {
             $Splat = @{
-                Uri = "https://api.spacexdata.com/v3/launches/upcoming"
+                Path = "launches/upcoming"
             }
         }
 
         else {
             $Splat = @{
-                Uri = "https://api.spacexdata.com/v3/launches"
+                Path = "launches"
             }
         }
 
-        (Invoke-RestMethod @Splat)
+        (Get-SXData @Splat)
     }
     catch {
         $PSCmdlet.ThrowTerminatingError($_)

--- a/SpaceX/public/Get-SXLaunchPad.ps1
+++ b/SpaceX/public/Get-SXLaunchPad.ps1
@@ -25,16 +25,16 @@ function Get-SXLaunchpad {
     try {
         if ($LaunchPad) {
             $Splat = @{
-                Uri = "https://api.spacexdata.com/v3/launchpads/$LaunchPad"
+                Path = "launchpads/$LaunchPad"
             }
         }
         else {
             $Splat = @{
-                Uri = "https://api.spacexdata.com/v3/launchpads"
+                Path = "launchpads"
             }
         }
 
-        (Invoke-RestMethod @Splat)
+        (Get-SXData @Splat)
     }
     catch {
         $PSCmdlet.ThrowTerminatingError($_)

--- a/SpaceX/public/Get-SXMission.ps1
+++ b/SpaceX/public/Get-SXMission.ps1
@@ -26,16 +26,16 @@ function Get-SXMission {
         if($Mission)
         {
             $Splat = @{
-                Uri = "https://api.spacexdata.com/v3/missions/$Mission"
+                Path = "missions/$Mission"
             }
         }
         else{
             $Splat = @{
-                Uri = "https://api.spacexdata.com/v3/missions"
+                Path = "missions"
             }
         }
 
-        (Invoke-RestMethod @Splat)
+        (Get-SXData @Splat)
     }
     catch{
         $PSCmdlet.ThrowTerminatingError($_)

--- a/SpaceX/public/Get-SXPayload.ps1
+++ b/SpaceX/public/Get-SXPayload.ps1
@@ -26,16 +26,16 @@ function Get-SXPayload {
       if($PayloadID)
       {
           $Splat = @{
-              Uri = "https://api.spacexdata.com/v3/payloads/$PayloadID"
+              Path = "payloads/$PayloadID"
           }
       }
       else{
           $Splat = @{
-              Uri = "https://api.spacexdata.com/v3/payloads"
+              Path = "payloads"
           }
       }
 
-      (Invoke-RestMethod @Splat)
+      (Get-SXData @Splat)
   }
   catch{
       $PSCmdlet.ThrowTerminatingError($_)

--- a/SpaceX/public/Get-SXRoadster.ps1
+++ b/SpaceX/public/Get-SXRoadster.ps1
@@ -17,9 +17,9 @@ function Get-SXRoadster {
   PARAM()
   try{
       $Splat = @{
-          Uri = "https://api.spacexdata.com/v3/roadster"
+          Path = "roadster"
       }
-      (Invoke-RestMethod @Splat)
+      (Get-SXData @Splat)
   }
   catch{
       $PSCmdlet.ThrowTerminatingError($_)

--- a/SpaceX/public/Get-SXRocket.ps1
+++ b/SpaceX/public/Get-SXRocket.ps1
@@ -26,16 +26,16 @@ function Get-SXRocket {
         if($Rocket)
         {
             $Splat = @{
-                Uri = "https://api.spacexdata.com/v3/rockets/$Rocket"
+                Path = "rockets/$Rocket"
             }
         }
         else{
             $Splat = @{
-                Uri = "https://api.spacexdata.com/v3/rockets"
+                Path = "rockets"
             }
         }
 
-        (Invoke-RestMethod @Splat)
+        (Get-SXData @Splat)
     }
     catch{
         $PSCmdlet.ThrowTerminatingError($_)

--- a/SpaceX/public/Get-SXShip.ps1
+++ b/SpaceX/public/Get-SXShip.ps1
@@ -26,16 +26,16 @@ function Get-SXShip {
       if($ShipID)
       {
           $Splat = @{
-              Uri = "https://api.spacexdata.com/v3/ships/$ShipID"
+              Path = "ships/$ShipID"
           }
       }
       else{
           $Splat = @{
-              Uri = "https://api.spacexdata.com/v3/ships"
+              Path = "ships"
           }
       }
 
-      (Invoke-RestMethod @Splat)
+      (Get-SXData @Splat)
   }
   catch{
       $PSCmdlet.ThrowTerminatingError($_)


### PR DESCRIPTION
During module initialisation, calls are made to `Get-SXApi` to see if it works without manually enabling TLS v1.2. If it does work - fine, carry on as normal. If it doesn't work, and TLS v1.2 needs to be manually set, then this is done only at the start of each API call, then is reset again immediately afterwards, thus not making any lasting changes to the PowerShell session. (Fixes #21 - again, but this time better in I think 😉)

To facilitate this, the calls to the API have been extracted to a new private function `Get-SXData` - fixes #2